### PR TITLE
Fixes #17 & #3 [EGNX] - Stand Mismatch and Gate 45 Pushback

### DIFF
--- a/EGNX (Pyreegue)/egnx-Pyreegue-Hinshee.ini
+++ b/EGNX (Pyreegue)/egnx-Pyreegue-Hinshee.ini
@@ -1,11 +1,9 @@
 [general]
 creator = Hinshee
 disable_static_docks = 0
-afcad_path = egnx-derby.bgl
-notes = Version 1.5
-	Updated 05/04/2024
+notes = Version 1.6
 
-[parking 4]
+[gate 4]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -53,7 +51,7 @@ disablepaxbarriers_deboarding = 0
 passengerpaththickness_deboarding = 2.5
 pushbacktype = 0
 
-[parking 5]
+[gate 5]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -102,7 +100,7 @@ disablepaxbarriers_deboarding = 0
 passengerpaththickness_deboarding = 2.5
 pushbacktype = 0
 
-[parking 6]
+[gate 6]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -152,7 +150,7 @@ pushbacktype = 0
 baggage_loader_main_pos = 52.8289105438357 -1.32761529562518 178.76683807373
 baggage_train_main_pos = 52.8287843587762 -1.32729074964773 -124.833161926271
 
-[parking 7]
+[gate 7]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -205,7 +203,7 @@ passengerpaththickness_deboarding = 2.5
 pushbacktype = 0
 baggage_train_main_pos = 52.8287762224016 -1.3273014289638 -121.816268920898
 
-[parking 8]
+[gate 8]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -255,7 +253,7 @@ passengerpaththickness_deboarding = 2.0
 passengerentergatepos_deboarding = (52.82680680576242, -1.3273264802368194, 0.0)
 passengerwaypoints_deboarding = [(52.827198196732866, -1.3277742803438275, 0.0), (52.8271670235218, -1.32772000570869, 0.0), (52.82702189453119, -1.3277095777910024, 0.0), (52.82702062537307, -1.327668091963954, 0.0), (52.826982481025496, -1.3274719505782264, 0.0), (52.826885352834516, -1.3274659884429143, 0.0)]
 
-[parking 9]
+[gate 9]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -307,7 +305,7 @@ passengerentergatepos_deboarding = (52.826807763247416, -1.3273273634574791, 0.0
 passengerwaypoints_deboarding = [(52.82714928615078, -1.328464057383148, 0.0), (52.827112018020905, -1.3284285593507943, 0.0), (52.82711277357824, -1.328227882219009, 0.0), (52.82700696719561, -1.3282217206676556, 0.0), (52.82702141444925, -1.3276689672504314, 0.0), (52.826981754446386, -1.3274727479967128, 0.0), (52.826886983942885, -1.327466908667013, 0.0)]
 pushbacktype = 0
 
-[parking 10]
+[gate 10]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -358,7 +356,7 @@ disablepaxbarriers_deboarding = 0
 passengerpaththickness_deboarding = 2.5
 pushbacktype = 0
 
-[parking 11]
+[gate 11]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -408,7 +406,7 @@ nopassengerbus_deboarding = 0
 disablepaxbarriers_deboarding = 0
 passengerpaththickness_deboarding = 2.5
 
-[parking 12l]
+[gate 12l]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -456,7 +454,7 @@ nopassengerbus_deboarding = 0
 disablepaxbarriers_deboarding = 0
 passengerpaththickness_deboarding = 2.5
 
-[parking 12r]
+[gate 12r]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -507,7 +505,7 @@ nopassengerbus_deboarding = 0
 disablepaxbarriers_deboarding = 0
 passengerpaththickness_deboarding = 2.5
 
-[parking 14l]
+[gate 14l]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -556,7 +554,7 @@ nopassengerbus_deboarding = 0
 disablepaxbarriers_deboarding = 0
 passengerpaththickness_deboarding = 2.5
 
-[parking 14r]
+[gate 14r]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -604,7 +602,7 @@ nopassengerbus_deboarding = 0
 disablepaxbarriers_deboarding = 0
 passengerpaththickness_deboarding = 2.5
 
-[parking 15]
+[gate 15]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -654,7 +652,7 @@ nopassengerbus_deboarding = 0
 disablepaxbarriers_deboarding = 0
 passengerpaththickness_deboarding = 2.5
 
-[parking 16]
+[gate 16]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -706,7 +704,7 @@ nopassengerbus_deboarding = 0
 disablepaxbarriers_deboarding = 0
 passengerpaththickness_deboarding = 2.5
 
-[parking 17]
+[gate 17]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -762,7 +760,7 @@ disablepaxbarriers_deboarding = 0
 passengerpaththickness_deboarding = 2.5
 nopassengerbus_deboarding = 0
 
-[parking 20]
+[gate 20]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -811,7 +809,7 @@ disablepaxbarriers_deboarding = 0
 pushbacktype = 0
 passengerpaththickness_deboarding = 2.5
 
-[parking 21]
+[gate 21]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -851,7 +849,7 @@ this_parking_pos = 52.8285523817518 -1.32940061215098 178.49430847168
 parkingsystem_objectposition = 52.8282439386085 -1.32938681529284 -1.50569152832032 0
 parkingsystem_stopposition = 52.8284309325997 -1.32939532528802 178.49430847168
 
-[parking 23]
+[gate 23]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -890,7 +888,7 @@ stairs_rear_pos = 52.8288800290869 -1.33036945402941 178.199996948242
 parkingsystem_objectposition = 52.8282995638192 -1.33067178238062 -1.80000305175784 0
 parkingsystem_stopposition = 52.8284078285949 -1.33067742834313 178.199996948242
 
-[parking 24]
+[gate 24]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -932,7 +930,7 @@ parkingsystem_stopposition = 52.8284670123961 -1.33042915859626 133.199996948242
 baggage_loader_main_pos = 52.8288897712227 -1.33015637187127 -91.800003051758
 baggage_train_main_pos = 52.8288990573278 -1.33003810479993 -91.800003051758
 
-[parking 30]
+[gate 30]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -979,7 +977,7 @@ nopassengerbus_deboarding = 0
 disablepaxbarriers_deboarding = 0
 passengerpaththickness_deboarding = 2.5
 
-[parking 31]
+[gate 31]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -1029,7 +1027,7 @@ nopassengerbus_deboarding = 0
 disablepaxbarriers_deboarding = 0
 passengerpaththickness_deboarding = 2.5
 
-[parking 32]
+[gate 32]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -1080,7 +1078,7 @@ nopassengerbus_deboarding = 0
 disablepaxbarriers_deboarding = 0
 passengerpaththickness_deboarding = 2.5
 
-[parking 33]
+[gate 33]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -1132,7 +1130,7 @@ nopassengerbus_deboarding = 0
 disablepaxbarriers_deboarding = 0
 passengerpaththickness_deboarding = 2.5
 
-[parking 40]
+[gate 40]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -1179,7 +1177,7 @@ disablepaxbarriers_deboarding = 0
 passengerpaththickness_deboarding = 2.5
 pushbacktype = 0
 
-[parking 41]
+[gate 41]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -1229,7 +1227,7 @@ passengerpaththickness_deboarding = 2.5
 pushbacktype = 0
 pushbackleftapproachpos2 = 52.82788998 -1.336060821 -1.881003451
 
-[parking 42]
+[gate 42]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -1277,7 +1275,7 @@ disablepaxbarriers_deboarding = 0
 passengerpaththickness_deboarding = 2.5
 pushbacktype = 0
 
-[parking 43]
+[gate 43]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -1323,7 +1321,7 @@ nopassengerbus_deboarding = 0
 disablepaxbarriers_deboarding = 0
 passengerpaththickness_deboarding = 2.5
 
-[parking 44]
+[gate 44]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -1369,7 +1367,7 @@ nopassengerbus_deboarding = 0
 disablepaxbarriers_deboarding = 0
 passengerpaththickness_deboarding = 2.5
 
-[parking 45]
+[gate 45]
 nopassengerstairs = 0
 nopassengerbus = 1
 ignoreicaoprefixes = 0
@@ -1382,7 +1380,7 @@ disablepaxbarriers = 1
 parkingsystem = Marshaller
 hasjetway = 0
 pushback = 0
-pushbackaddpos = [{'snap': False, 'approach': [(52.82691697585228, -1.3353818388164462, 87.9934339592074), None, None, None, None, None, None, None, None], 'pos': (52.8269415597, -1.33586966579, 68.7599969482), 'label': u'Standard (Straight Push on N)'}]
+pushbackaddpos = [{'snap': False, 'approach': [(52.82691697585228, -1.3353818388164462, 87.9934339592074), None, None, None, None, None, None, None, None], 'pos': (52.82695979017705, -1.3357922298417577, 68.7599969482), 'label': u'Standard (Straight Push on N)'}]
 pushbacklabels = Nose Right/Tail Left (LEFT)|Nose Left/Tail Right (RIGHT)
 maxwingspan = 38.0
 radiusleft = 19.0
@@ -1412,8 +1410,9 @@ passengerwaypoints = [(52.827041100034876, -1.3347371462129194, 9.34788948688657
 nopassengerbus_deboarding = 0
 disablepaxbarriers_deboarding = 0
 passengerpaththickness_deboarding = 2.5
+pushbacktype = 0
 
-[none 99]
+[w parking 99]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -1460,7 +1459,7 @@ stairs_rear_pos = 52.8274332197919 -1.34635033941438 -91.8000030517579
 parkingsystem_objectposition = 52.8272678133708 -1.34681668874019 -1.80000305175784 0
 parkingsystem_stopposition = 52.8274258276503 -1.34682268925487 178.199996948242
 
-[none 100]
+[w parking 100]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -1506,7 +1505,7 @@ stairs_rear_pos = 52.8274332197919 -1.34635033941438 -91.8000030517579
 parkingsystem_objectposition = 52.8272589198706 -1.34687813428654 -1.80000305175784 0
 parkingsystem_stopposition = 52.8274537208918 -1.34688789882885 178.199996948242
 
-[none 101]
+[w parking 101]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -1553,7 +1552,7 @@ stairs_rear_pos = 52.827226349147 -1.34711871910105 -1.80000305175795
 parkingsystem_objectposition = 52.8271831405746 -1.34768862790497 -1.80000305175784 0
 parkingsystem_stopposition = 52.8272976499312 -1.34769459770936 178.199996948242
 
-[none 102]
+[w parking 102]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -1600,7 +1599,7 @@ stairs_rear_pos = 52.827267601402 -1.34801291418316 -1.80000305175795
 parkingsystem_objectposition = 52.8272326456552 -1.348661920049 -1.80000305175784 0
 parkingsystem_stopposition = 52.8273908536892 -1.3486701570765 178.199996948242
 
-[none 103]
+[w parking 103]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -1647,7 +1646,7 @@ stairs_rear_pos = 52.8272283760147 -1.34916525448055 -1.80000305175805
 parkingsystem_objectposition = 52.8272165779186 -1.34952602228165 -1.80000305175784 0
 parkingsystem_stopposition = 52.8273126731528 -1.34953103669609 178.199996948242
 
-[none 104]
+[w parking 104]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -1694,7 +1693,7 @@ stairs_rear_pos = 52.827208504224 -1.34991345393018 -1.80000305175795
 parkingsystem_objectposition = 52.8271933007484 -1.35035048658946 -1.80000305175784 0
 parkingsystem_stopposition = 52.8273331369197 -1.35035665717944 178.199996948242
 
-[none 105]
+[w parking 105]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -1741,7 +1740,7 @@ stairs_rear_pos = 52.8271925655018 -1.35070332436803 -1.80000305175795
 parkingsystem_objectposition = 52.8271798944969 -1.35112564524904 -1.80000305175784 0
 parkingsystem_stopposition = 52.8273197399878 -1.35113107416686 178.199996948242
 
-[none 106]
+[w parking 106]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -1789,7 +1788,7 @@ parkingsystem_objectposition = 52.827164605303 -1.35191599235017 -1.800003051757
 parkingsystem_stopposition = 52.8272974813445 -1.35192031753793 178.199996948242
 this_parking_pos = 52.8275320682838 -1.35193510898423 178.199996948242
 
-[none 107]
+[w parking 107]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -1838,7 +1837,7 @@ parkingsystem_stopposition = 52.8271009202304 -1.35214999776114 178.199996948242
 stairs_middle_pos = 52.8272690003147 -1.3515679900487 -61.8000030517578
 this_parking_pos = 52.8273232350253 -1.35216267241389 178.199996948242
 
-[none 108]
+[w parking 108]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -1885,7 +1884,7 @@ stairs_rear_pos = 52.8271681124078 -1.35224297442668 -1.80000305175795
 parkingsystem_objectposition = 52.8271075447867 -1.35265093567367 -1.80000305175784 0
 parkingsystem_stopposition = 52.8272076746053 -1.35265653044926 178.199996948242
 
-[none 109]
+[w parking 109]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -1933,7 +1932,7 @@ this_parking_pos = 52.827317558623 -1.35340057131594 178.199996948242
 parkingsystem_objectposition = 52.8269468094268 -1.35338091177845 -1.80000305175784 0
 parkingsystem_stopposition = 52.8271424446173 -1.35338960632108 178.199996948242
 
-[none 110]
+[w parking 110]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -1980,7 +1979,7 @@ stairs_rear_pos = 52.8271414844622 -1.35372202754987 -1.80000305175795
 parkingsystem_objectposition = 52.8271154076445 -1.35412509869707 -1.80000305175784 0
 parkingsystem_stopposition = 52.8272575672114 -1.3541302766013 178.199996948242
 
-[none 111]
+[w parking 111]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -2031,7 +2030,7 @@ disablepaxbarriers_deboarding = 0
 pushbacktype = 0
 passengerpaththickness_deboarding = 2.5
 
-[none 112]
+[w parking 112]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -2079,7 +2078,7 @@ parkingsystem_objectposition = 52.8271037148576 -1.35486539056777 -1.80000305175
 parkingsystem_stopposition = 52.8272437975598 -1.3548712028619 178.199996948242
 this_parking_pos = 52.8274254138578 -1.35488213273622 178.199996948242
 
-[none 114]
+[w parking 114]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -2126,7 +2125,7 @@ disablepaxbarriers_deboarding = 0
 pushbacktype = 0
 passengerpaththickness_deboarding = 2.5
 
-[none 120]
+[w parking 120]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -2170,7 +2169,7 @@ stairs_rear_pos = 52.8272967819433 -1.34608993461951 -1.79998779296875
 parkingsystem_objectposition = 52.8275888437584 -1.34645256667626 88.2000122070312 0
 parkingsystem_stopposition = 52.8275920149998 -1.34621424218805 -91.7999877929688
 
-[none 121]
+[w parking 121]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -2220,7 +2219,7 @@ parkingsystem_objectposition = 52.8270667930612 -1.34638695660726 88.20001220703
 parkingsystem_stopposition = 52.8270717539941 -1.3460546050297 -91.7999877929688
 baggage_train_main_pos = 52.8274006153867 -1.3462057349714 88.2000122070312
 
-[none 122]
+[w parking 122]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -2264,7 +2263,7 @@ stairs_rear_pos = 52.8267871772854 -1.34619309715251 88.2000122070313
 parkingsystem_objectposition = 52.82697662907 -1.34623125812591 88.2000122070312 0
 parkingsystem_stopposition = 52.8269817253451 -1.34591541407025 -91.7999877929688
 
-[none 123]
+[w parking 123]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -2308,7 +2307,7 @@ stairs_rear_pos = 52.8264440971659 -1.3461658933641 88.2000122070313
 parkingsystem_objectposition = 52.8266382256398 -1.34607644668385 88.2000122070312 0
 parkingsystem_stopposition = 52.8266407283547 -1.34589685512528 -91.7999877929688
 
-[none 124]
+[w parking 124]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -2352,7 +2351,7 @@ stairs_rear_pos = 52.8261034962218 -1.34614339301361 88.2000122070313
 parkingsystem_objectposition = 52.8262956260836 -1.3460408656113 88.2000122070312 0
 parkingsystem_stopposition = 52.8262970884215 -1.34588050734238 -91.7999877929688
 
-[none 125]
+[w parking 125]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -2397,7 +2396,7 @@ parkingsystem_objectposition = 52.8259017291576 -1.34617829319424 88.20001220703
 parkingsystem_stopposition = 52.8259071213937 -1.34589413878563 -91.7999877929688
 this_parking_pos = 52.8259116421451 -1.34566785069989 -91.7999877929688
 
-[none 125r]
+[w parking 125r]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -2427,7 +2426,7 @@ usercustomized = 1
 handlingtexture = DHL,DHL_WHITE
 cateringtexture = DNATA
 
-[none 125l]
+[w parking 125l]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -2457,7 +2456,7 @@ walkerpaththickness = 2.5
 walkerloopstart = 0
 usercustomized = 1
 
-[parking 70]
+[e parking 70]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -2501,7 +2500,7 @@ parkingsystem_objectposition = 52.8283688957815 -1.323298180213 38.1999969482422
 parkingsystem_stopposition = 52.8284869860201 -1.32314419310334 -141.800003051758
 stairs_rear_pos = 52.8279115222149 -1.32228970593791 -1.40000305175802
 
-[parking 70r]
+[e parking 70r]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -2546,7 +2545,7 @@ parkingsystem_objectposition = 52.8285182463738 -1.32327484300818 38.27239990234
 parkingsystem_stopposition = 52.8286364250465 -1.32312033983801 -141.727600097656
 stairs_rear_pos = 52.8279124108511 -1.32227919459521 -4.32760009765629
 
-[parking 70l]
+[e parking 70l]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -2591,7 +2590,7 @@ parkingsystem_objectposition = 52.8282932457557 -1.32316549079511 38.19999694824
 parkingsystem_stopposition = 52.8283903908691 -1.32303871593311 -141.800003051758
 stairs_rear_pos = 52.8279165206185 -1.32228825389705 -0.800003051758058
 
-[parking 71]
+[e parking 71]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -2634,7 +2633,7 @@ stairs_front_pos = 52.8279151133375 -1.32229344396917 -1.10000305175824
 parkingsystem_objectposition = 52.8282136328156 -1.32277119832887 33.6999969482422 0
 parkingsystem_stopposition = 52.8283136536216 -1.32266011631754 -146.300003051758
 
-[parking 72]
+[e parking 72]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -2677,7 +2676,7 @@ stairs_front_pos = 52.8279061831221 -1.32166562211793 -26.3000030517578
 parkingsystem_objectposition = 52.8280958871408 -1.32245253214498 33.6999969482422 0
 parkingsystem_stopposition = 52.8281931680536 -1.3223431296348 -146.300003051758
 
-[parking 73]
+[e parking 73]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -2721,7 +2720,7 @@ parkingsystem_objectposition = 52.8280341032828 -1.32229707753358 33.69999694824
 parkingsystem_stopposition = 52.8281179609372 -1.32220423875954 -146.300003051758
 stairs_rear_pos = 52.8279055768529 -1.32154042942952 -10.1000030517577
 
-[parking 73l]
+[e parking 73l]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -2766,7 +2765,7 @@ parkingsystem_objectposition = 52.8277898958625 -1.32199477138582 -1.80000305175
 parkingsystem_stopposition = 52.8279051255681 -1.32200337620044 178.199996948242
 stairs_rear_pos = 52.8279009075629 -1.32153858240071 -1.8000030517581
 
-[parking 74]
+[e parking 74]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -2810,7 +2809,7 @@ parkingsystem_objectposition = 52.8278002779468 -1.32138755831457 -1.80000305175
 parkingsystem_stopposition = 52.8279270007969 -1.3213945329592 178.199996948242
 stairs_rear_pos = 52.8280523591915 -1.32085296824579 -91.8000030517579
 
-[parking 74l]
+[e parking 74l]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -2854,7 +2853,7 @@ parkingsystem_objectposition = 52.8278008728498 -1.32131618537958 -1.80000305175
 parkingsystem_stopposition = 52.8279275658475 -1.3213235295557 178.199996948242
 stairs_rear_pos = 52.8280529506565 -1.32086323344026 -91.8000030517579
 
-[parking 75]
+[e parking 75]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -2898,7 +2897,7 @@ parkingsystem_objectposition = 52.8278622372823 -1.32057001509947 -1.80000305175
 parkingsystem_stopposition = 52.8280257541614 -1.32057852771197 178.199996948242
 stairs_rear_pos = 52.828034401614 -1.32001643342335 -1.80000305175795
 
-[parking 75r]
+[e parking 75r]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -2942,7 +2941,7 @@ parkingsystem_objectposition = 52.8279793340463 -1.32071947136407 -1.80000305175
 parkingsystem_stopposition = 52.8281214568268 -1.32072687396423 178.199996948242
 stairs_rear_pos = 52.8280224359741 -1.32001075387889 -1.80000305175795
 
-[parking 76]
+[e parking 76]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -2989,7 +2988,7 @@ pushbackleftapproachpos2 = 52.82880424 -1.319391555 -92.3815105
 pushbackrightpos = 52.82878785 -1.320214177 88.2464447
 pushbackrightapproachpos = 52.8284768 -1.319802235 178.2594943
 
-[parking 76r]
+[e parking 76r]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -3037,7 +3036,7 @@ parkingsystem_objectposition = 52.8280039607378 -1.32017394076857 -1.72807312011
 parkingsystem_stopposition = 52.8281300220618 -1.32018098947661 178.271926879883
 stairs_rear_pos = 52.8280329800031 -1.31944999195081 -1.72807312011708
 
-[parking 76l]
+[e parking 76l]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -3084,7 +3083,7 @@ parkingsystem_objectposition = 52.8280133510098 -1.31962745400879 -1.75355529785
 parkingsystem_stopposition = 52.828140520732 -1.31963539395521 178.246444702148
 stairs_rear_pos = 52.8280402818055 -1.3191479485128 -1.75355529785156
 
-[parking 77r]
+[e parking 77r]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -3131,7 +3130,7 @@ stairs_rear_pos = 52.8280503930887 -1.31862547446149 -1.80000305175795
 parkingsystem_objectposition = 52.8280100224469 -1.31908199202243 -1.80000305175784 0
 parkingsystem_stopposition = 52.8281492724558 -1.31908924555132 178.199996948242
 
-[parking 78r]
+[e parking 78r]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -3178,7 +3177,7 @@ parkingsystem_objectposition = 52.8279195961275 -1.31852958607309 -1.80000305175
 parkingsystem_stopposition = 52.8281160227358 -1.31854129052983 178.199996948242
 stairs_rear_pos = 52.8278461395858 -1.31766530499614 -46.8000030517579
 
-[parking 78l]
+[e parking 78l]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -3225,7 +3224,7 @@ parkingsystem_objectposition = 52.8279833375214 -1.31799164997275 -1.80000305175
 parkingsystem_stopposition = 52.8281249490946 -1.31799976823873 178.199996948242
 this_parking_pos = 52.8282459241053 -1.31800643556538 178.199996948242
 
-[parking 79]
+[e parking 79]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -3269,7 +3268,7 @@ parkingsystem_objectposition = 52.8278903842974 -1.31743064097135 -1.80000305175
 parkingsystem_stopposition = 52.828135681003 -1.31744413888685 178.199996948242
 stairs_rear_pos = 52.8278229430845 -1.31693884406304 -1.80000305175795
 
-[parking 80]
+[e parking 80]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -3314,7 +3313,7 @@ this_parking_pos = 52.8281506161202 -1.31688640686628 178.199996948242
 parkingsystem_objectposition = 52.8278194517216 -1.31686917648484 -1.80000305175784 0
 parkingsystem_stopposition = 52.8280285113457 -1.3168800520228 178.199996948242
 
-[parking 81]
+[e parking 81]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -3359,7 +3358,7 @@ parkingsystem_objectposition = 52.8278831682715 -1.31666811084876 -1.80000305175
 parkingsystem_stopposition = 52.8280156254556 -1.31667612521397 178.199996948242
 stairs_rear_pos = 52.8279872690096 -1.31598000718582 -91.8000030517581
 
-[parking 82]
+[e parking 82]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -3404,7 +3403,7 @@ stairs_rear_pos = 52.8280362301202 -1.31568500192542 -91.8000030517579
 parkingsystem_objectposition = 52.8278881635184 -1.31628955762728 -1.80000305175784 0
 parkingsystem_stopposition = 52.8279891353599 -1.31629482507471 178.199996948242
 
-[parking 83]
+[e parking 83]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -3450,7 +3449,7 @@ parkingsystem_objectposition = 52.8279195582511 -1.3151563273607 -46.73370361328
 parkingsystem_stopposition = 52.8280687763312 -1.31542143386619 133.266296386719
 stairs_rear_pos = 52.8284711439212 -1.31531572521023 178.266296386719
 
-[parking 84]
+[e parking 84]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -3498,7 +3497,7 @@ parkingsystem_stopposition = 52.8285643261677 -1.31528583728265 88.1999969482422
 stairs_rear_pos = 52.8290579256466 -1.31597038852328 178.199996948242
 this_parking_pos = 52.8285597566731 -1.31557382462432 88.1999969482422
 
-[parking 85]
+[e parking 85]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -3542,7 +3541,7 @@ stairs_front_pos = 52.8290087081542 -1.31528525418189 -151.800003051758
 parkingsystem_objectposition = 52.8287979205822 -1.31513386800817 -91.8000030517578 0
 parkingsystem_stopposition = 52.828792838469 -1.31536637916852 88.1999969482422
 
-[parking 86]
+[e parking 86]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -3588,7 +3587,7 @@ parkingsystem_objectposition = 52.8289187763388 -1.31513383766518 -91.8000030517
 parkingsystem_stopposition = 52.8289162618538 -1.31530230504875 88.1999969482422
 stairs_rear_pos = 52.8285990321288 -1.31519340942012 -46.8000030517579
 
-[parking 78]
+[e parking 78]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -3633,7 +3632,7 @@ pushbackleftapproachpos = 52.82845032 -1.318144385 178.3025604
 pushbackrightpos = 52.82882063 -1.318512576 88.19999695
 pushbackrightapproachpos = 52.82845007 -1.318157341 178.0974335
 
-[parking 77]
+[e parking 77]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -3678,7 +3677,7 @@ pushbackleftapproachpos = 52.82848593 -1.318970072 178.2873572
 pushbackrightpos = 52.8288014 -1.319547643 88.19999695
 pushbackrightapproachpos = 52.8284859 -1.318971634 178.1126367
 
-[parking 22]
+[gate 22]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -3722,7 +3721,7 @@ pushbackleftapproachpos = 52.82822634 -1.330030322 -1.845179503
 pushbackrightpos = 52.82792081 -1.330493243 88.38537598
 pushbackrightapproachpos = 52.82822626 -1.330035246 -361.3840685
 
-[none 98]
+[w parking 98]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -3773,7 +3772,7 @@ disablepaxbarriers_deboarding = 0
 pushbacktype = 0
 passengerpaththickness_deboarding = 2.5
 
-[none 200]
+[w parking 200]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -3803,7 +3802,7 @@ walkerpaththickness = 2.5
 walkerloopstart = 0
 usercustomized = 1
 
-[none 201]
+[w parking 201]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -3833,7 +3832,7 @@ walkerpaththickness = 2.5
 walkerloopstart = 0
 usercustomized = 1
 
-[none 201l]
+[w parking 201l]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -3863,7 +3862,7 @@ walkerpaththickness = 2.5
 walkerloopstart = 0
 usercustomized = 1
 
-[none 201r]
+[w parking 201r]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -3893,7 +3892,7 @@ walkerpaththickness = 2.5
 walkerloopstart = 0
 usercustomized = 1
 
-[none 202]
+[w parking 202]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -3923,7 +3922,7 @@ walkerpaththickness = 2.5
 walkerloopstart = 0
 usercustomized = 1
 
-[none 202l]
+[w parking 202l]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -3953,7 +3952,7 @@ walkerpaththickness = 2.5
 walkerloopstart = 0
 usercustomized = 1
 
-[none 202r]
+[w parking 202r]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -3983,7 +3982,7 @@ walkerpaththickness = 2.5
 walkerloopstart = 0
 usercustomized = 1
 
-[none 203]
+[w parking 203]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0
@@ -4013,7 +4012,7 @@ walkerpaththickness = 2.5
 walkerloopstart = 0
 usercustomized = 1
 
-[none 203r]
+[w parking 203r]
 nopassengerstairs = 0
 nopassengerbus = 0
 ignoreicaoprefixes = 0

--- a/EGNX (Pyreegue)/egnx-Pyreegue-Hinshee.py
+++ b/EGNX (Pyreegue)/egnx-Pyreegue-Hinshee.py
@@ -21,12 +21,13 @@ CentralApronRemoteNames = RemoteStandName("Central Aprons", "", 1)
 EasternApron = StandName("Eastern Apron", "", 2)
 WesternApron = StandName("Western Apron", "", 2)
 WesternApronRemote = RemoteStandNameNC("Western Apron", "", 2)
-MainAreaNorthNames = StandName("GA Aprons | Maint. North (NC)", "", 3)
-MainAreaSouthNames = StandName("GA Aprons | Maint. South (NC)", "", 3)
+MainAreaNorthNames = StandName("North Maintenance | Maint. (NC)", "", 4)
+MainAreaSouthNames = StandName("South Maintenance | Maint. (NC)", "", 4)
 RVLApronNames = StandName("GA Aprons | RVL Apron (NC)", "", 3)
+RollsRoyceApron = StandName("GA Aprons | Rolls Royce Apron (NC)", "", 3)
 
 parkings = {
-	PARKING : {
+	GATE : {
 		None : ( ),
 		4 : (CentralApronNames, ),
 		5 : (CentralApronNames, ),
@@ -37,8 +38,12 @@ parkings = {
 		10 : (CentralApronNames, ),
 		11 : (CentralApronNames, ),
 		12 : (CentralApronNames, ),
+		"12L" : (CentralApronNames, ),
+		"12R" : (CentralApronNames, ),
 		13 : (CentralApronNames, ),
 		14 : (CentralApronNames, ),
+		"14L" : (CentralApronNames, ),
+		"14R" : (CentralApronNames, ),
 		15 : (CentralApronNames, ),
 		16 : (CentralApronNames, ),
 		17 : (CentralApronNames, ),
@@ -57,36 +62,11 @@ parkings = {
 		43 : (CentralWestApronNames, ),
 		44 : (CentralWestApronNames, ),
 		45 : (CentralWestApronNames, ),
-		"70R" : (EasternApron, ),
-		70 : (EasternApron, ),
-		"70L" : (EasternApron, ),
-		71 : (EasternApron, ),
-		72 : (EasternApron, ),
-		73 : (EasternApron, ),
-		"73L" : (EasternApron, ),
-		74 : (EasternApron, ),
-		"74L" : (EasternApron, ),
-		75 : (EasternApron, ),
-		"75R" : (EasternApron, ),
-		"76R" : (EasternApron, ),
-		76 : (EasternApron, ),
-		"76L" : (EasternApron, ),
-		"77R" : (EasternApron, ),
-		77 : (EasternApron, ),
-		"78R" : (EasternApron, ),
-		78 : (EasternApron, ),
-		"78L" : (EasternApron, ),
-		79 : (EasternApron, ),
-		80 : (EasternApron, ),
-		81 : (EasternApron, ),
-		82 : (EasternApron, ),
-		83 : (EasternApron, ),
-		84 : (EasternApron, ),
-		85 : (EasternApron, ),
-		86 : (EasternApron, ),
 	},
-	0 : {
+	W_PARKING : {
 		None : ( ),
+		1 : (RollsRoyceApron, ),
+		2 : (RVLApronNames, ),
 		98 : (WesternApron, ),
 		99 : (WesternApron, ),
 		100 : (WesternApron, ),
@@ -121,15 +101,45 @@ parkings = {
 		203 : (WesternApronRemote, ),
 		"203R" : (WesternApronRemote, ),
 	},
+	E_PARKING : {
+		None : (MainAreaNorthNames, ),
+		"70R" : (EasternApron, ),
+		70 : (EasternApron, ),
+		"70L" : (EasternApron, ),
+		71 : (EasternApron, ),
+		72 : (EasternApron, ),
+		73 : (EasternApron, ),
+		"73L" : (EasternApron, ),
+		74 : (EasternApron, ),
+		"74L" : (EasternApron, ),
+		75 : (EasternApron, ),
+		"75R" : (EasternApron, ),
+		"76R" : (EasternApron, ),
+		76 : (EasternApron, ),
+		"76L" : (EasternApron, ),
+		"77R" : (EasternApron, ),
+		77 : (EasternApron, ),
+		"78R" : (EasternApron, ),
+		78 : (EasternApron, ),
+		"78L" : (EasternApron, ),
+		79 : (EasternApron, ),
+		80 : (EasternApron, ),
+		81 : (EasternApron, ),
+		82 : (EasternApron, ),
+		83 : (EasternApron, ),
+		84 : (EasternApron, ),
+		85 : (EasternApron, ),
+		86 : (EasternApron, ),
+	},
 	SW_PARKING : {
 		None : (MainAreaNorthNames, ),
+		1 : (MainAreaNorthNames, ),
+		2 : (MainAreaNorthNames, ),
+		3 : (MainAreaNorthNames, ),
 	},
 	S_PARKING : {
 		None : (MainAreaSouthNames, ),
 		1 : (MainAreaSouthNames, ),
 		2 : (MainAreaSouthNames, ),
-	},
-	W_PARKING : {
-		None : (RVLApronNames, ),
 	},
 }


### PR DESCRIPTION
Fixes #17 and #3

## Bugs
As a result of Version 1.0.31 of the scenery, which brought about gate fixes, 90 parking have been identified as mismatching.
Additionally, Stand 45's pushback was a little too far. This has been corrected.

## Updated Version Number
Version 1.6